### PR TITLE
Do not open viewer in other 2 return modes

### DIFF
--- a/R/dot.R
+++ b/R/dot.R
@@ -147,7 +147,7 @@ dot <- function(DOT, file = NULL, return = "auto") {
     write(content, file=dotFile, append=TRUE)
 
     viewer <- getOption("viewer")
-    if (!is.null(viewer)) {
+    if (!is.null(viewer) & return == "auto") {
         viewer(dotFile)
     }
     #else {


### PR DESCRIPTION
Sometimes there is no need to see the plot, and saving to an object is enough. 
Change it to open the viewer only when the return is on auto mode.